### PR TITLE
Add query-signature argument, add ethereum-input-decoder to requirements

### DIFF
--- a/mythril/disassembler/disassembly.py
+++ b/mythril/disassembler/disassembly.py
@@ -5,7 +5,7 @@ import logging
 
 class Disassembly(object):
 
-    def __init__(self, code, enable_online_lookup=True):
+    def __init__(self, code, enable_online_lookup=False):
         self.instruction_list = asm.disassemble(util.safe_decode(code))
         self.func_hashes = []
         self.func_to_addr = {}

--- a/mythril/ether/ethcontract.py
+++ b/mythril/ether/ethcontract.py
@@ -6,7 +6,7 @@ import re
 
 class ETHContract(persistent.Persistent):
 
-    def __init__(self, code, creation_code="", name="Unknown", enable_online_lookup=True):
+    def __init__(self, code, creation_code="", name="Unknown", enable_online_lookup=False):
         
         # Workaround: We currently do not support compile-time linking.
         # Dynamic contract addresses of the format __[contract-name]_____________ are replaced with a generic address

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -15,6 +15,7 @@ import argparse
 from mythril.exceptions import CriticalError, AddressNotFoundError
 from mythril.mythril import Mythril
 from mythril.version import VERSION
+import mythril.support.signatures as sigs
 
 
 def exit_with_error(format, message):
@@ -78,6 +79,7 @@ def main():
     options.add_argument('--phrack', action='store_true', help='Phrack-style call graph')
     options.add_argument('--enable-physics', action='store_true', help='enable graph physics simulation')
     options.add_argument('-v', type=int, help='log level (0-2)', metavar='LOG_LEVEL')
+    options.add_argument('-q', '--query-signature', action='store_true', help='Lookup function signatures through www.4byte.directory')
 
     rpc = parser.add_argument_group('RPC options')
     rpc.add_argument('-i', action='store_true', help='Preset: Infura Node service (Mainnet)')
@@ -102,6 +104,7 @@ def main():
         parser.print_help()
         sys.exit()
 
+
     if args.v:
         if 0 <= args.v < 3:
             coloredlogs.install(
@@ -110,6 +113,12 @@ def main():
             )
         else:
             exit_with_error(args.outform, "Invalid -v value, you can find valid values in usage")
+
+    if args.query_signature:
+        if sigs.ethereum_input_decoder == None:
+            exit_with_error(args.outform, "The --query-signature function requires the python package ethereum-input-decoder")
+    else:
+        sigs.ethereum_input_decoder = None
 
     # -- commands --
     if args.hash:

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -117,8 +117,6 @@ def main():
     if args.query_signature:
         if sigs.ethereum_input_decoder == None:
             exit_with_error(args.outform, "The --query-signature function requires the python package ethereum-input-decoder")
-    else:
-        sigs.ethereum_input_decoder = None
 
     # -- commands --
     if args.hash:
@@ -131,7 +129,8 @@ def main():
         # solc_args = None, dynld = None, max_recursion_depth = 12):
 
         mythril = Mythril(solv=args.solv, dynld=args.dynld,
-                          solc_args=args.solc_args)
+                          solc_args=args.solc_args,
+                          enable_online_lookup=args.query_signature)
         if args.dynld and not (args.rpc or args.i):
             mythril.set_api_from_config_path()
 

--- a/mythril/mythril.py
+++ b/mythril/mythril.py
@@ -76,15 +76,17 @@ class Mythril(object):
 
     """
     def __init__(self, solv=None,
-                 solc_args=None, dynld=False):
+                 solc_args=None, dynld=False, 
+                 enable_online_lookup=False):
 
         self.solv = solv
         self.solc_args = solc_args
         self.dynld = dynld
+        self.enable_online_lookup = enable_online_lookup
 
         self.mythril_dir = self._init_mythril_dir()
 
-        self.sigs = signatures.SignatureDb()
+        self.sigs = signatures.SignatureDb(enable_online_lookup=self.enable_online_lookup)
         try:
             self.sigs.open()  # tries mythril_dir/signatures.json by default (provide path= arg to make this configurable)
         except FileNotFoundError as fnfe:
@@ -279,7 +281,7 @@ class Mythril(object):
 
     def load_from_bytecode(self, code):
         address = util.get_indexed_address(0)
-        self.contracts.append(ETHContract(code, name="MAIN"))
+        self.contracts.append(ETHContract(code, name="MAIN", enable_online_lookup=self.enable_online_lookup))
         return address, self.contracts[-1]  # return address and contract object
 
     def load_from_address(self, address):
@@ -298,7 +300,7 @@ class Mythril(object):
             if code == "0x" or code == "0x0":
                  raise CriticalError("Received an empty response from eth_getCode. Check the contract address and verify that you are on the correct chain.")
             else:
-                self.contracts.append(ETHContract(code, name=address))
+                self.contracts.append(ETHContract(code, name=address, enable_online_lookup=self.enable_online_lookup))
         return address, self.contracts[-1]  # return address and contract object
 
     def load_from_solidity(self, solidity_files):

--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -54,7 +54,7 @@ except ImportError:
 
 class SignatureDb(object):
 
-    def __init__(self, enable_online_lookup=True):
+    def __init__(self, enable_online_lookup=False):
         """
         Constr
         :param enable_online_lookup: enable onlien signature hash lookup

--- a/mythril/support/signatures.py
+++ b/mythril/support/signatures.py
@@ -11,7 +11,6 @@ from subprocess import Popen, PIPE
 from mythril.exceptions import CompilerError
 
 
-# todo: tintinweb - make this a normal requirement? (deps: eth-abi and requests, both already required by mythril)
 try:
     # load if available but do not fail
     import ethereum_input_decoder

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ coverage
 eth_abi>=1.0.0
 eth-account>=0.1.0a2
 ethereum>=2.3.2
-ethereum-input-decoder==0.2.2
+ethereum-input-decoder>=0.2.2
 eth-hash>=0.1.0
 eth-keyfile>=0.5.1
 eth-keys>=0.2.0b3

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ coverage
 eth_abi>=1.0.0
 eth-account>=0.1.0a2
 ethereum>=2.3.2
+ethereum-input-decoder==0.2.2
 eth-hash>=0.1.0
 eth-keyfile>=0.5.1
 eth-keys>=0.2.0b3

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,8 @@ setup(
         'py-flags',
         'mock',
         'configparser>=3.5.0',
-        'persistent>=4.2.0'
+        'persistent>=4.2.0',
+        'ethereum-input-decoder>=0.2.2'
     ],
 
     tests_require=[

--- a/tests/report_test.py
+++ b/tests/report_test.py
@@ -23,7 +23,7 @@ def _fix_debug_data(json_str):
 
 
 def _generate_report(input_file):
-    contract = ETHContract(input_file.read_text())
+    contract = ETHContract(input_file.read_text(), enable_online_lookup=False)
     sym = SymExecWrapper(contract, address=(util.get_indexed_address(0)), strategy="dfs", execution_timeout=30)
     issues = fire_lasers(sym)
 


### PR DESCRIPTION
This PR adds the ethereum-input-decoder python module to the requirements installed with pip and adds an argument -q/--query-signature to enable function signature lookups through www.4byte.directory.

"Fixes" https://github.com/ConsenSys/mythril/issues/590.