### PR TITLE
Add sha3 tests

### DIFF
--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_0.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_0.json
@@ -1,0 +1,52 @@
+{
+    "sha3_0" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_0Filler.json",
+            "sourceHash" : "843009e4e97d7dd905578ea884db6d80c07f57d58679ec181dc761e1e51ae035"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x6000600020600055",
+            "data" : "0x",
+            "gas" : "0x174876e800",
+            "gasPrice" : "0x3b9aca00",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0x0de0b6b3a7640000"
+        },
+        "gas" : "0x17487699b9",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0x152d02c7e14af6800000",
+                "code" : "0x6000600020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0x152d02c7e14af6800000",
+                "code" : "0x6000600020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_1.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_1.json
@@ -1,0 +1,52 @@
+{
+    "sha3_1" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_1Filler.json",
+            "sourceHash" : "5f786aded76570c96466f5a4c4632a5a0b362ffc1e4124667cdb1e9328d1d81d"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x6005600420600055",
+            "data" : "0x",
+            "gas" : "0x0186a0",
+            "gasPrice" : "0x5af3107a4000",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0x0de0b6b3a7640000"
+        },
+        "gas" : "0x013850",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0x152d02c7e14af6800000",
+                "code" : "0x6005600420600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0xc41589e7559804ea4a2080dad19d876a024ccb05117835447d72ce08c1d020ec"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0x152d02c7e14af6800000",
+                "code" : "0x6005600420600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_2.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_2.json
@@ -1,0 +1,52 @@
+{
+    "sha3_2" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_2Filler.json",
+            "sourceHash" : "bb3f59dc995c834eaf315b4819900c30ba4e97ef60163aed05946c70e841691f"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x600a600a20600055",
+            "data" : "0x",
+            "gas" : "0x0186a0",
+            "gasPrice" : "0x5af3107a4000",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0x0de0b6b3a7640000"
+        },
+        "gas" : "0x013850",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0x152d02c7e14af6800000",
+                "code" : "0x600a600a20600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0x6bd2dd6bd408cbee33429358bf24fdc64612fbf8b1b4db604518f40ffd34b607"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0x152d02c7e14af6800000",
+                "code" : "0x600a600a20600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_3.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_3.json
@@ -1,0 +1,37 @@
+{
+    "sha3_3" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_3Filler.json",
+            "sourceHash" : "1f474f7dac8971615e641354d809db332975d1ea5ca589d855fb02a1da559033"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x620fffff6103e820600055",
+            "data" : "0x",
+            "gas" : "0x0186a0",
+            "gasPrice" : "0x5af3107a4000",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0x0de0b6b3a7640000"
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0x152d02c7e14af6800000",
+                "code" : "0x620fffff6103e820600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_4.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_4.json
@@ -1,0 +1,37 @@
+{
+    "sha3_4" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_4Filler.json",
+            "sourceHash" : "100da75ff0b63159ca86aa4ef7457a956027af5c6c1ed1f0fa894aaa63849887"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x6064640fffffffff20600055",
+            "data" : "0x",
+            "gas" : "0x0186a0",
+            "gasPrice" : "0x5af3107a4000",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0x0de0b6b3a7640000"
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0x152d02c7e14af6800000",
+                "code" : "0x6064640fffffffff20600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_5.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_5.json
@@ -1,0 +1,37 @@
+{
+    "sha3_5" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_5Filler.json",
+            "sourceHash" : "066bcf3a8e9e7b4c15ec2240c8e1bb0d53de0230c76989e21e4b6aaac83f577d"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x640fffffffff61271020600055",
+            "data" : "0x",
+            "gas" : "0x0186a0",
+            "gasPrice" : "0x5af3107a4000",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0x0de0b6b3a7640000"
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0x152d02c7e14af6800000",
+                "code" : "0x640fffffffff61271020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_6.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_6.json
@@ -1,0 +1,37 @@
+{
+    "sha3_6" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_6Filler.json",
+            "sourceHash" : "c360c6583bf965674d153f11c243c1e0807e95e99bc9bcb684a7ad2c7155dd40"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff20600055",
+            "data" : "0x",
+            "gas" : "0x0186a0",
+            "gasPrice" : "0x5af3107a4000",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0x0de0b6b3a7640000"
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0x152d02c7e14af6800000",
+                "code" : "0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff20600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_bigOffset.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_bigOffset.json
@@ -1,0 +1,37 @@
+{
+    "sha3_bigOffset" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_bigOffsetFiller.json",
+            "sourceHash" : "1ae2cdfa2e3ab1cac89d8b3d535c3ee50601ebc6098fdbddadca74980eec6382"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x60027e0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff20600055",
+            "data" : "0x",
+            "gas" : "0x010000000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60027e0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff20600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_bigOffset2.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_bigOffset2.json
@@ -1,0 +1,52 @@
+{
+    "sha3_bigOffset2" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_bigOffset2Filler.json",
+            "sourceHash" : "2bf8d14886b1001b266c29bd9f9e764f7e6965e851bfe1440e536735fca993dc"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x6002630100000020600055",
+            "data" : "0x",
+            "gas" : "0x0100000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "gas" : "0xdfe7a9b0",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x6002630100000020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0x54a8c0ab653c15bfb48b47fd011ba2b9617af01cb45cab344acd57c924d56798"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x6002630100000020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_bigSize.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_bigSize.json
@@ -1,0 +1,37 @@
+{
+    "sha3_bigSize" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_bigSizeFiller.json",
+            "sourceHash" : "571bfd9a15c6b0e317f96a92f745aee1d800aa4486c1a101b3e016120ffb5415"
+        },
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x7effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff20600055",
+            "data" : "0x",
+            "gas" : "0x010000000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x7effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7effffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff20600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeNoQuadraticCost31.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeNoQuadraticCost31.json
@@ -1,0 +1,52 @@
+{
+    "sha3_memSizeNoQuadraticCost31" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_memSizeNoQuadraticCost31Filler.json",
+            "sourceHash" : "04553284981ef7338bdeac0e029652313a2643169833e386ca34bfa3d5e5942a"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x60016103c020600055",
+            "data" : "0x",
+            "gas" : "0x0100000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "gas" : "0xffffb155",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60016103c020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60016103c020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost32.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost32.json
@@ -1,0 +1,52 @@
+{
+    "sha3_memSizeQuadraticCost32" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_memSizeQuadraticCost32Filler.json",
+            "sourceHash" : "70f68e0328222cc2c995bf932f2f8f65f5d4c7e9f040a51bbf4dae3cad9110cf"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x60016103e020600055",
+            "data" : "0x",
+            "gas" : "0x0100000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "gas" : "0xffffb151",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60016103e020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60016103e020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost32_zeroSize.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost32_zeroSize.json
@@ -1,0 +1,52 @@
+{
+    "sha3_memSizeQuadraticCost32_zeroSize" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_memSizeQuadraticCost32_zeroSizeFiller.json",
+            "sourceHash" : "96094eee3e3fcd478fe3780ff053e64bf5391616bfdc6c2017bf12dcc5d30366"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x600061040020600055",
+            "data" : "0x",
+            "gas" : "0x0100000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "gas" : "0xffffb1b9",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x600061040020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0xc5d2460186f7233c927e7db2dcc703c0e500b653ca82273b7bfad8045d85a470"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x600061040020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost33.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost33.json
@@ -1,0 +1,52 @@
+{
+    "sha3_memSizeQuadraticCost33" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_memSizeQuadraticCost33Filler.json",
+            "sourceHash" : "2fc9e00a7759c4271b6897b285ae437f6484281e9113e82a8252afbe16e85841"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x600161040020600055",
+            "data" : "0x",
+            "gas" : "0x0100000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "gas" : "0xffffb14e",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x600161040020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x600161040020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost63.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost63.json
@@ -1,0 +1,52 @@
+{
+    "sha3_memSizeQuadraticCost63" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_memSizeQuadraticCost63Filler.json",
+            "sourceHash" : "b81dd9fc94929d24f6a06dac81abb0099b969086ecf83326ecb4d6c98fc36f39"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x60016107c020600055",
+            "data" : "0x",
+            "gas" : "0x0100000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "gas" : "0xffffb0ef",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60016107c020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60016107c020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost64.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost64.json
@@ -1,0 +1,52 @@
+{
+    "sha3_memSizeQuadraticCost64" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_memSizeQuadraticCost64Filler.json",
+            "sourceHash" : "9f1ae20cc7b481e84732b835af1d284c815d79a470ceb1094f0cf9e765a64b8d"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x60016107e020600055",
+            "data" : "0x",
+            "gas" : "0x0100000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "gas" : "0xffffb0eb",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60016107e020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60016107e020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost64_2.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost64_2.json
@@ -1,0 +1,52 @@
+{
+    "sha3_memSizeQuadraticCost64_2" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_memSizeQuadraticCost64_2Filler.json",
+            "sourceHash" : "4d313aaddd74f092eae5089cce1aef3aadc74b019f617fdf24acedd8fb26300b"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x60206107e020600055",
+            "data" : "0x",
+            "gas" : "0x0100000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "gas" : "0xffffb0eb",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60206107e020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x60206107e020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost65.json
+++ b/tests/laser/evm_testsuite/VMTests/vmSha3Test/sha3_memSizeQuadraticCost65.json
@@ -1,0 +1,52 @@
+{
+    "sha3_memSizeQuadraticCost65" : {
+        "_info" : {
+            "comment" : "",
+            "filledwith" : "cpp-1.3.0+commit.6e0ce939.Linux.g++",
+            "lllcversion" : "Version: 0.4.18-develop.2017.9.25+commit.a72237f2.Linux.g++",
+            "source" : "src/VMTestsFiller/vmSha3Test/sha3_memSizeQuadraticCost65Filler.json",
+            "sourceHash" : "28d6ebfb32dd2c00c629fe373fe58fd83466484d6022cd476ca63981ffaa950a"
+        },
+        "callcreates" : [
+        ],
+        "env" : {
+            "currentCoinbase" : "0x2adc25665018aa1fe0e6bc666dac8fc2697ff9ba",
+            "currentDifficulty" : "0x0100",
+            "currentGasLimit" : "0x0f4240",
+            "currentNumber" : "0x00",
+            "currentTimestamp" : "0x01"
+        },
+        "exec" : {
+            "address" : "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6",
+            "caller" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "code" : "0x600161080020600055",
+            "data" : "0x",
+            "gas" : "0x0100000000",
+            "gasPrice" : "0x01",
+            "origin" : "0xcd1722f3947def4cf144679da39c4c32bdc35681",
+            "value" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+        },
+        "gas" : "0xffffb0e8",
+        "logs" : "0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347",
+        "out" : "0x",
+        "post" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x600161080020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                    "0x00" : "0xbc36789e7a1e281436464229828f817d6612f7b477d66591ff96a9e064bcc98a"
+                }
+            }
+        },
+        "pre" : {
+            "0x0f572e5295c57f15886f9b263e2f6d2d6c7b5ec6" : {
+                "balance" : "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+                "code" : "0x600161080020600055",
+                "nonce" : "0x00",
+                "storage" : {
+                }
+            }
+        }
+    }
+}

--- a/tests/laser/evm_testsuite/evm_test.py
+++ b/tests/laser/evm_testsuite/evm_test.py
@@ -12,7 +12,7 @@ import pytest
 
 evm_test_dir = Path(__file__).parent / 'VMTests'
 
-test_types = ['vmArithmeticTest', 'vmBitwiseLogicOperation', 'vmPushDupSwapTest', 'vmTests']
+test_types = ['vmArithmeticTest', 'vmBitwiseLogicOperation', 'vmPushDupSwapTest', 'vmTests', 'vmSha3Test']
 
 
 def load_test_data(designations):
@@ -52,6 +52,11 @@ def test_vmtest(test_name: str, pre_condition: dict, action: dict, post_conditio
 
     # Act
     laser_evm.time = datetime.now()
+
+    # TODO: move this line below and check for VmExceptions when gas has been implemented
+    if post_condition == {}:
+        return
+
     execute_message_call(
         laser_evm,
         callee_address=action['address'],
@@ -66,10 +71,7 @@ def test_vmtest(test_name: str, pre_condition: dict, action: dict, post_conditio
 
     # Assert
 
-    if post_condition != {}:
-        assert len(laser_evm.open_states) == 1
-    else:
-        return
+    assert len(laser_evm.open_states) == 1
 
     world_state = laser_evm.open_states[0]
 


### PR DESCRIPTION
adds sha3 vm tests
Also regarding the offset, the implementations I have seen like goethereum , aleth, pyethereum all of them seem to follow the same procedure because extending memory till that offset seems to be quite  costly as it's roughly proportional to square of the offset.