### PR TITLE
Raise z3 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,5 +24,5 @@ pytest_mock
 requests
 rlp>=1.0.1
 transaction>=2.2.1
-z3-solver==4.5.1.0.post2
+z3-solver==4.8.0.0.post1
 pysha3

--- a/setup.py
+++ b/setup.py
@@ -75,7 +75,7 @@ setup(
     install_requires=[
         "coloredlogs>=10.0",
         "ethereum>=2.3.2",
-        "z3-solver==4.5.1.0.post2",
+        "z3-solver==4.8.0.0.post1",
         "requests",
         "py-solc",
         "plyvel",


### PR DESCRIPTION
Just to triple check, @b-mueller can you confirm that mythril + z3 4.8 discovers the exception:
```solidity
pragma solidity ^0.4.21;

contract TokenSale {
    mapping(address => uint256) public balanceOf;
    uint256 constant PRICE_PER_TOKEN = 1 ether;

    function TokenSale(address _player) public payable {
        require(msg.value == 1 ether);
    }

    function isComplete() public view returns (bool) {
        return address(this).balance < 1 ether;
    }

     function buy(uint256 numTokens) public payable {

        require(msg.value == numTokens * PRICE_PER_TOKEN);

        assert(!(msg.value == 0 && numTokens > 0));

        balanceOf[msg.sender] += numTokens;
    }


    function sell(uint256 numTokens) public {
        require(balanceOf[msg.sender] >= numTokens);

        balanceOf[msg.sender] -= numTokens;
        msg.sender.transfer(numTokens * PRICE_PER_TOKEN);
    }
}
```