### PR TITLE
Increase default max-transaction-count to 2

### DIFF
--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -169,7 +169,7 @@ def main():
     options.add_argument(
         "--max-transaction-count",
         type=int,
-        default=1,
+        default=2,
         help="Maximum number of transactions issued by laser",
     )
     options.add_argument(


### PR DESCRIPTION
Setting max-tx-count was a panic fix during the workshop. 2 tx seems to be a sensible default for the myth command line tool (with only 1 tx we miss simple bugs like initialized contracts and misnamed constructors).

This should become irrelevant once we have callbacks / analysis timeout implemented.