### PR TITLE
Deepcopy account state before deletion on selfdestuct

### DIFF
--- a/mythril/laser/ethereum/instructions.py
+++ b/mythril/laser/ethereum/instructions.py
@@ -1194,6 +1194,13 @@ class Instruction:
                 )
                 account_created = True
 
+        global_state.environment.active_account = deepcopy(
+            global_state.environment.active_account
+        )
+        global_state.accounts[
+            global_state.environment.active_account.address
+        ] = global_state.environment.active_account
+
         global_state.environment.active_account.balance = 0
         global_state.environment.active_account.deleted = True
         global_state.current_transaction.end(global_state)


### PR DESCRIPTION
Fixes a bug where Mythril would prematurely stop symbolic execution when encountering a SUICIDE instruction.