### PR TITLE
Introduce additional constraints in Ether Thief module

### DIFF
--- a/mythril/analysis/modules/ether_thief.py
+++ b/mythril/analysis/modules/ether_thief.py
@@ -36,7 +36,7 @@ class EtherThief(DetectionModule):
         )
 
     def execute(self, state_space):
-        logging.debug("Executing module: " + format(self.name))
+        logging.debug("Executing module: %s", self.name)
         issues = []
 
         for k in state_space.nodes:


### PR DESCRIPTION
An "ETH relay" contract is often found on the mainnet. This contract contains a function that sends its balance to a fixed address ([example](https://etherscan.io/address/0x94e934139ae32efa180beaecc7e92dbe141de9bd#code)). This PR narrows the win condition by adding the following constraints:

- The receiver address must be is identical to the sender address;
- The sender address can be chosen arbitrarily.