### PR TITLE
Add highlight for solidity files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,5 @@
 tests/testdata/* linguist-detectable=false
 static/* linguist-documentation
+
+# Solidity
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Enables Solidity syntax highlight for files ending in `.sol`