### PR TITLE
Update version

### DIFF
--- a/mythril/version.py
+++ b/mythril/version.py
@@ -1,3 +1,3 @@
 # This file is suitable for sourcing inside POSIX shell, e.g. bash as
 # well as for importing into Python
-VERSION = "v0.19.8"  # NOQA
+VERSION = "v0.19.9"  # NOQA


### PR DESCRIPTION
Due to the eth-abi update, all the mythril versions aren't easily download-able. So we need a version release. fixes #814 