### PR TITLE
Log number of open states at start of tx

### DIFF
--- a/mythril/laser/ethereum/svm.py
+++ b/mythril/laser/ethereum/svm.py
@@ -149,7 +149,11 @@ class LaserEVM:
             initial_coverage = self._get_covered_instructions()
 
             self.time = datetime.now()
-            log.info("Starting message call transaction, iteration: {}, {} initial states".format(i, len(self.open_states)))
+            log.info(
+                "Starting message call transaction, iteration: {}, {} initial states".format(
+                    i, len(self.open_states)
+                )
+            )
 
             execute_message_call(self, address)
 

--- a/mythril/laser/ethereum/svm.py
+++ b/mythril/laser/ethereum/svm.py
@@ -149,7 +149,7 @@ class LaserEVM:
             initial_coverage = self._get_covered_instructions()
 
             self.time = datetime.now()
-            log.info("Starting message call transaction, iteration: {}".format(i))
+            log.info("Starting message call transaction, iteration: {}, {} initial states".format(i, len(self.open_states)))
 
             execute_message_call(self, address)
 


### PR DESCRIPTION
Adds:

```
$ myth -x solidity_examples/weak_random.sol -v4
(...)
mythril.laser.ethereum.svm [INFO]: Starting contract creation transaction
mythril.laser.ethereum.svm [INFO]: Finished contract creation, found 1 open states
mythril.laser.ethereum.svm [INFO]: Starting message call transaction, iteration: 0, 1 initial states
mythril.laser.ethereum.svm [INFO]: Number of new instructions covered in tx 0: 529
mythril.laser.ethereum.svm [INFO]: Starting message call transaction, iteration: 1, 162 initial states
```