### PR TITLE
Stores the entire statespace only when necessary

### DIFF
--- a/mythril/analysis/modules/base.py
+++ b/mythril/analysis/modules/base.py
@@ -35,7 +35,8 @@ class DetectionModule:
             "DetectionModule "
             "name={0.name} "
             "swc_id={0.swc_id} "
-            "hooks={0.hooks} "
+            "pre_hooks={0.pre_hooks} "
+            "post_hooks={0.post_hooks} "
             "description={0.description}"
             ">"
         ).format(self)

--- a/mythril/laser/ethereum/svm.py
+++ b/mythril/laser/ethereum/svm.py
@@ -49,6 +49,7 @@ class LaserEVM:
         create_timeout=10,
         strategy=DepthFirstSearchStrategy,
         transaction_count=2,
+        requires_statespace=False,
     ):
         world_state = WorldState()
         world_state.accounts = accounts
@@ -56,8 +57,6 @@ class LaserEVM:
         self.world_state = world_state
         self.open_states = [world_state]
 
-        self.nodes = {}
-        self.edges = []
         self.coverage = {}
 
         self.total_states = 0
@@ -70,6 +69,11 @@ class LaserEVM:
 
         self.execution_timeout = execution_timeout
         self.create_timeout = create_timeout
+
+        self.requires_statespace = requires_statespace
+        if self.requires_statespace:
+            self.nodes = {}
+            self.edges = []
 
         self.time = None
 
@@ -124,12 +128,13 @@ class LaserEVM:
             self._execute_transactions(created_account.address)
 
         log.info("Finished symbolic execution")
-        log.info(
-            "%d nodes, %d edges, %d total states",
-            len(self.nodes),
-            len(self.edges),
-            self.total_states,
-        )
+        if self.requires_statespace:
+            log.info(
+                "%d nodes, %d edges, %d total states",
+                len(self.nodes),
+                len(self.edges),
+                self.total_states,
+            )
         for code, coverage in self.coverage.items():
             cov = (
                 reduce(lambda sum_, val: sum_ + 1 if val else sum_, coverage[1])
@@ -362,10 +367,13 @@ class LaserEVM:
         old_node = state.node
         state.node = new_node
         new_node.constraints = state.mstate.constraints
-        self.nodes[new_node.uid] = new_node
-        self.edges.append(
-            Edge(old_node.uid, new_node.uid, edge_type=edge_type, condition=condition)
-        )
+        if self.requires_statespace:
+            self.nodes[new_node.uid] = new_node
+            self.edges.append(
+                Edge(
+                    old_node.uid, new_node.uid, edge_type=edge_type, condition=condition
+                )
+            )
 
         if edge_type == JumpType.RETURN:
             new_node.flags |= NodeFlags.CALL_RETURN

--- a/mythril/laser/ethereum/svm.py
+++ b/mythril/laser/ethereum/svm.py
@@ -49,7 +49,7 @@ class LaserEVM:
         create_timeout=10,
         strategy=DepthFirstSearchStrategy,
         transaction_count=2,
-        requires_statespace=False,
+        requires_statespace=True,
     ):
         world_state = WorldState()
         world_state.accounts = accounts

--- a/mythril/laser/ethereum/transaction/concolic.py
+++ b/mythril/laser/ethereum/transaction/concolic.py
@@ -56,8 +56,9 @@ def _setup_global_state_for_execution(laser_evm, transaction) -> None:
 
     new_node = Node(global_state.environment.active_account.contract_name)
 
-    laser_evm.nodes[new_node.uid] = new_node
-    if transaction.world_state.node:
+    if laser_evm.requires_statespace:
+        laser_evm.nodes[new_node.uid] = new_node
+    if transaction.world_state.node and laser_evm.requires_statespace:
         laser_evm.edges.append(
             Edge(
                 transaction.world_state.node.uid,
@@ -66,6 +67,7 @@ def _setup_global_state_for_execution(laser_evm, transaction) -> None:
                 condition=None,
             )
         )
+
     global_state.node = new_node
     new_node.states.append(global_state)
     laser_evm.work_list.append(global_state)

--- a/mythril/laser/ethereum/transaction/symbolic.py
+++ b/mythril/laser/ethereum/transaction/symbolic.py
@@ -103,8 +103,8 @@ def _setup_global_state_for_execution(laser_evm, transaction) -> None:
         function_name=global_state.environment.active_function_name,
     )
     if laser_evm.requires_statespace:
-      laser_evm.nodes[new_node.uid] = new_node
-      
+        laser_evm.nodes[new_node.uid] = new_node
+
     if transaction.world_state.node:
         if laser_evm.requires_statespace:
             laser_evm.edges.append(

--- a/mythril/laser/ethereum/transaction/symbolic.py
+++ b/mythril/laser/ethereum/transaction/symbolic.py
@@ -105,17 +105,18 @@ def _setup_global_state_for_execution(laser_evm, transaction) -> None:
     global_state.transaction_stack.append((transaction, None))
 
     new_node = Node(global_state.environment.active_account.contract_name)
-
-    laser_evm.nodes[new_node.uid] = new_node
+    if laser_evm.requires_statespace:
+        laser_evm.nodes[new_node.uid] = new_node
     if transaction.world_state.node:
-        laser_evm.edges.append(
-            Edge(
-                transaction.world_state.node.uid,
-                new_node.uid,
-                edge_type=JumpType.Transaction,
-                condition=None,
+        if laser_evm.requires_statespace:
+            laser_evm.edges.append(
+                Edge(
+                    transaction.world_state.node.uid,
+                    new_node.uid,
+                    edge_type=JumpType.Transaction,
+                    condition=None,
+                )
             )
-        )
 
         global_state.mstate.constraints += transaction.world_state.node.constraints
         new_node.constraints = global_state.mstate.constraints

--- a/mythril/mythril.py
+++ b/mythril/mythril.py
@@ -496,6 +496,7 @@ class Mythril(object):
                     create_timeout=create_timeout,
                     transaction_count=transaction_count,
                     modules=modules,
+                    compulsory_statespace=False,
                 )
                 issues = fire_lasers(sym, modules)
             except KeyboardInterrupt:

--- a/mythril/support/truffle.py
+++ b/mythril/support/truffle.py
@@ -56,6 +56,8 @@ def analyze_truffle_project(sigs, args):
                 create_timeout=args.create_timeout,
                 execution_timeout=args.execution_timeout,
                 transaction_count=args.transaction_count,
+                modules=args.modules,
+                compulsory_statespace=False,
             )
             issues = fire_lasers(sym)
 

--- a/mythril/support/truffle.py
+++ b/mythril/support/truffle.py
@@ -56,7 +56,7 @@ def analyze_truffle_project(sigs, args):
                 create_timeout=args.create_timeout,
                 execution_timeout=args.execution_timeout,
                 transaction_count=args.transaction_count,
-                modules=args.modules,
+                modules=args.modules or [],
                 compulsory_statespace=False,
             )
             issues = fire_lasers(sym)


### PR DESCRIPTION
Store nodes only when module with entrypoint="post" should be executed or a html graph statespace needs to be constructed or when statespace has to be dumped. This makes contracts like BECToken.sol executable in the computers of the ordinary people.