### PR TITLE
Enable analysis at specific blocknumber for dynamic loader

### DIFF
--- a/mythril/ethereum/interface/rpc/base_client.py
+++ b/mythril/ethereum/interface/rpc/base_client.py
@@ -78,7 +78,7 @@ class BaseClient(object):
         NEEDS TESTING
         """
         block = validate_block(block)
-        return self._call("eth_getCode", [address, default_block])
+        return self._call("eth_getCode", [address, block])
 
     def eth_getBlockByNumber(self, block=BLOCK_TAG_LATEST, tx_objects=True):
         """TODO: documentation

--- a/mythril/ethereum/interface/rpc/base_client.py
+++ b/mythril/ethereum/interface/rpc/base_client.py
@@ -70,16 +70,14 @@ class BaseClient(object):
         block = validate_block(block)
         return self._call("eth_getStorageAt", [address, hex(position), block])
 
-    def eth_getCode(self, address, default_block=BLOCK_TAG_LATEST):
+    def eth_getCode(self, address, block=BLOCK_TAG_LATEST):
         """TODO: documentation
 
         https://github.com/ethereum/wiki/wiki/JSON-RPC#eth_getcode
 
         NEEDS TESTING
         """
-        if isinstance(default_block, str):
-            if default_block not in BLOCK_TAGS:
-                raise ValueError
+        block = validate_block(block)
         return self._call("eth_getCode", [address, default_block])
 
     def eth_getBlockByNumber(self, block=BLOCK_TAG_LATEST, tx_objects=True):

--- a/mythril/ethereum/interface/rpc/utils.py
+++ b/mythril/ethereum/interface/rpc/utils.py
@@ -33,6 +33,9 @@ def validate_block(block):
             raise ValueError("invalid block tag")
     if isinstance(block, int):
         block = hex(block)
+        if len(block) % 2 is not 0:
+            block = "0x0{}".format(block[2:])
+            
     return block
 
 

--- a/mythril/ethereum/interface/rpc/utils.py
+++ b/mythril/ethereum/interface/rpc/utils.py
@@ -35,7 +35,7 @@ def validate_block(block):
         block = hex(block)
         if len(block) % 2 is not 0:
             block = "0x0{}".format(block[2:])
-            
+
     return block
 
 

--- a/mythril/interfaces/cli.py
+++ b/mythril/interfaces/cli.py
@@ -100,6 +100,13 @@ def main():
         help="auto-load dependencies from the blockchain",
     )
     inputs.add_argument(
+        "-b",
+        "--block",
+        type=int,
+        help="specify a specific block for loading from the blockchain, must have dynamic loading enabled",
+        default="latest",
+    )
+    inputs.add_argument(
         "--no-onchain-storage-access",
         action="store_true",
         help="turns off getting the data from onchain contracts",
@@ -314,6 +321,7 @@ def main():
             onchain_storage_access=(not args.no_onchain_storage_access),
             solc_args=args.solc_args,
             enable_online_lookup=args.query_signature,
+            block=args.block,
         )
         if (
             args.dynld

--- a/mythril/mythril.py
+++ b/mythril/mythril.py
@@ -87,6 +87,7 @@ class Mythril(object):
         dynld=False,
         enable_online_lookup=False,
         onchain_storage_access=True,
+        block='latest',
     ):
 
         self.solv = solv
@@ -108,6 +109,7 @@ class Mythril(object):
 
         self.eth = None  # ethereum API client
         self.eth_db = None  # ethereum LevelDB client
+        self.block = block
 
         self.contracts = []  # loaded contracts
 
@@ -388,7 +390,8 @@ class Mythril(object):
             raise CriticalError("Invalid contract address. Expected format is '0x...'.")
 
         try:
-            code = self.eth.eth_getCode(address)
+            # should realy use dyn loader for consistency
+            code = self.eth.eth_getCode(address, block = self.block)
         except FileNotFoundError as e:
             raise CriticalError("IPC error: " + str(e))
         except ConnectionError:

--- a/mythril/mythril.py
+++ b/mythril/mythril.py
@@ -87,7 +87,7 @@ class Mythril(object):
         dynld=False,
         enable_online_lookup=False,
         onchain_storage_access=True,
-        block='latest',
+        block="latest",
     ):
 
         self.solv = solv
@@ -391,7 +391,7 @@ class Mythril(object):
 
         try:
             # should realy use dyn loader for consistency
-            code = self.eth.eth_getCode(address, block = self.block)
+            code = self.eth.eth_getCode(address, block=self.block)
         except FileNotFoundError as e:
             raise CriticalError("IPC error: " + str(e))
         except ConnectionError:

--- a/mythril/support/loader.py
+++ b/mythril/support/loader.py
@@ -10,7 +10,7 @@ log = logging.getLogger(__name__)
 class DynLoader:
     """The dynamic loader class."""
 
-    def __init__(self, eth, contract_loading=True, storage_loading=True):
+    def __init__(self, eth, contract_loading=True, storage_loading=True, block="latest"):
         """
 
         :param eth:
@@ -21,6 +21,7 @@ class DynLoader:
         self.storage_cache = {}
         self.contract_loading = contract_loading
         self.storage_loading = storage_loading
+        self.block = block
 
     def read_storage(self, contract_address: str, index: int):
         """
@@ -43,7 +44,7 @@ class DynLoader:
             self.storage_cache[contract_address] = {}
 
             data = self.eth.eth_getStorageAt(
-                contract_address, position=index, block="latest"
+                contract_address, position=index, block=self.block
             )
 
             self.storage_cache[contract_address][index] = data
@@ -51,7 +52,7 @@ class DynLoader:
         except IndexError:
 
             data = self.eth.eth_getStorageAt(
-                contract_address, position=index, block="latest"
+                contract_address, position=index, block=self.block
             )
 
             self.storage_cache[contract_address][index] = data
@@ -85,7 +86,7 @@ class DynLoader:
 
         log.debug("Dependency address: " + dependency_address)
 
-        code = self.eth.eth_getCode(dependency_address)
+        code = self.eth.eth_getCode(dependency_address, block=self.block)
 
         if code == "0x":
             return None

--- a/mythril/support/loader.py
+++ b/mythril/support/loader.py
@@ -10,7 +10,9 @@ log = logging.getLogger(__name__)
 class DynLoader:
     """The dynamic loader class."""
 
-    def __init__(self, eth, contract_loading=True, storage_loading=True, block="latest"):
+    def __init__(
+        self, eth, contract_loading=True, storage_loading=True, block="latest"
+    ):
         """
 
         :param eth:


### PR DESCRIPTION
When running an archive node, one might be interested in analysing contracts at a specific block when using the dynamic loader.

This pull request provides such functionality, adding a command line option and additionally padding requests to even length conforming to [paritys API](https://wiki.parity.io/JSONRPC#types-in-the-jsonrpc) (go ethereum accepts both).