### PR TITLE
Set default tx count to 1 in graph generator

### DIFF
--- a/mythril/mythril/mythril_analyzer.py
+++ b/mythril/mythril/mythril_analyzer.py
@@ -84,7 +84,7 @@ class MythrilAnalyzer:
         contract: EVMContract = None,
         enable_physics: bool = False,
         phrackify: bool = False,
-        transaction_count: Optional[int] = None,
+        transaction_count: Optional[int] = 1,
     ) -> str:
         """
 


### PR DESCRIPTION
Fixes crash when tx count is not explicitly provided.